### PR TITLE
Specify parse.js (instead of parse.min.js) as main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "parse",
   "version": "1.9.1",
   "main": [
-    "parse.min.js"
+    "parse.js"
   ],
   "keywords": [
     "parse",


### PR DESCRIPTION
Fixes #21 
